### PR TITLE
Add writeByte. Add support for I2C restarts

### DIFF
--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -47,6 +47,16 @@ class sfeTkIBus
 {
   public:
     /*--------------------------------------------------------------------------
+        @brief Write a single byte to the device
+
+        @param data Data to write.
+
+        @retval sfeTkError_t -  kSTkErrOk on successful execution.
+
+    */
+    virtual sfeTkError_t writeByte(uint8_t data) = 0;
+
+    /*--------------------------------------------------------------------------
         @brief Write a single byte to the given register
 
         @param devReg The device's register's address.

--- a/src/sfeTk/sfeTkII2C.h
+++ b/src/sfeTk/sfeTkII2C.h
@@ -34,7 +34,7 @@ class sfeTkII2C : public sfeTkIBus
     sfeTkII2C() : _address{kNoAddress}
     {
     }
-    sfeTkII2C(uint8_t addr) : _address{addr}
+    sfeTkII2C(uint8_t addr) : _address{addr}, _stop{true}
     {
     }
 
@@ -68,10 +68,31 @@ class sfeTkII2C : public sfeTkIBus
         return _address;
     }
 
+    /*--------------------------------------------------------------------------
+        @brief setter for I2C stops (vs restarts)
+
+    */
+    virtual void setStop(uint8_t stop)
+    {
+        _stop = stop;
+    }
+
+    /*--------------------------------------------------------------------------
+        @brief getter for I2C stops (vs restarts)
+
+        @retval uint8_t returns the value of "send stop"
+
+    */
+    virtual uint8_t getStop(void)
+    {
+        return _stop;
+    }
+
     static constexpr uint8_t kNoAddress = 0;
 
   private:
     uint8_t _address;
+    uint8_t _stop;
 };
 
 //};

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -93,6 +93,16 @@ class sfeTkArdI2C : public sfeTkII2C
     sfeTkError_t ping();
 
     /*--------------------------------------------------------------------------
+        @brief Write a single byte to the device
+        @note sfeTkIBus interface method
+
+        @param data Data to write.
+
+        @retval returns  kStkErrOk on success
+    */
+    sfeTkError_t writeByte(uint8_t data);
+
+    /*--------------------------------------------------------------------------
         @brief Write a single byte to the given register
         @note sfeTkIBus interface method
 

--- a/src/sfeTkArdSPI.cpp
+++ b/src/sfeTkArdSPI.cpp
@@ -84,6 +84,33 @@ sfeTkError_t sfeTkArdSPI::init(bool bInit)
 //---------------------------------------------------------------------------------
 // writeRegisterByte()
 //
+// Writes a single byte to the device.
+//
+// Returns kSTkErrOk on success
+//
+sfeTkError_t sfeTkArdSPI::writeByte(uint8_t dataToWrite)
+{
+
+    if (!_spiPort)
+        return kSTkErrBusNotInit;
+
+    // Apply settings
+    _spiPort->beginTransaction(_sfeSPISettings);
+    // Signal communication start
+    digitalWrite(cs(), LOW);
+
+    _spiPort->transfer(dataToWrite);
+
+    // End communication
+    digitalWrite(cs(), HIGH);
+    _spiPort->endTransaction();
+
+    return kSTkErrOk;
+}
+
+//---------------------------------------------------------------------------------
+// writeRegisterByte()
+//
 // Writes a byte to a given register.
 //
 // Returns kSTkErrOk on success
@@ -108,6 +135,7 @@ sfeTkError_t sfeTkArdSPI::writeRegisterByte(uint8_t devReg, uint8_t dataToWrite)
 
     return kSTkErrOk;
 }
+
 //---------------------------------------------------------------------------------
 // writeRegisterWord()
 //

--- a/src/sfeTkArdSPI.h
+++ b/src/sfeTkArdSPI.h
@@ -83,6 +83,15 @@ class sfeTkArdSPI : public sfeTkISPI
     sfeTkError_t init(SPIClass &spiPort, SPISettings &busSPISettings, uint8_t csPin, bool bInit = false);
 
     /*--------------------------------------------------------------------------
+        @brief Write a single byte to the device
+
+        @param data Data to write.
+
+        @retval sfeTkError_t - kSTkErrOk on success
+    */
+    sfeTkError_t writeByte(uint8_t data);
+
+    /*--------------------------------------------------------------------------
         @brief Write a single byte to the given register
 
         @param devReg The device's register's address.


### PR DESCRIPTION
- Add ```writeByte``` for both I2C and SPI - needed by the ADS1219 on I2C
- Add support for I2C restart vs. stop
  - Many devices specify a restart between set-register-address and read-register-value
  - This is I2C-specific and may be needed on non-Arduino platforms too
  - Added ```setStop``` and ```getStop```
- Corrected ```readRegisterRegion```
  - The ```beginTransmission``` and ```endTransmission``` should be inside the ```if (bFirstInter)```