### PR TITLE
Add 16bit register support

### DIFF
--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -150,7 +150,7 @@ class sfeTkIBus
         @retval int returns kSTkErrOk on success, or kSTkErrFail code
 
     */
-    virtual sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes, size_t *readBytes = nullptr) = 0;
+    virtual sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes) = 0;
 
 };
 

--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -78,6 +78,7 @@ class sfeTkIBus
     */
     virtual sfeTkError_t writeRegisterWord(uint8_t devReg, uint16_t data) = 0;
 
+
     /*--------------------------------------------------------------------------
         @brief Writes a number of bytes starting at the given register's address.
 
@@ -89,6 +90,19 @@ class sfeTkIBus
 
     */
     virtual sfeTkError_t writeRegisterRegion(uint8_t devReg, const uint8_t *data, size_t length) = 0;
+
+    /*--------------------------------------------------------------------------
+        @brief Writes a number of bytes starting at the given register's 16-bit address.
+
+        @param devAddr The device's 16-bit address/pin
+        param devReg The device's register's address.
+        @param data Data to write.
+
+        @retval sfeTkError_t kSTkErrOk on successful execution
+
+    */
+    virtual sfeTkError_t write16BitRegisterRegion(uint16_t devReg, const uint8_t *data, size_t length) = 0;
+
 
     /*--------------------------------------------------------------------------
         @brief Read a single byte from the given register
@@ -124,6 +138,20 @@ class sfeTkIBus
 
     */
     virtual sfeTkError_t readRegisterRegion(uint8_t reg, uint8_t *data, size_t numBytes, size_t &readBytes) = 0;
+
+    /*--------------------------------------------------------------------------
+        @brief Reads a block of data from the given 16-bit register address.
+
+        @param reg The device's 16 bit register's address.
+        @param data Data to write.
+        @param numBytes - length of data
+        @param[out] readBytes - number of bytes read
+
+        @retval int returns kSTkErrOk on success, or kSTkErrFail code
+
+    */
+    virtual sfeTkError_t read16BitRegisterRegion(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes) = 0;
+
 };
 
 //};

--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -101,7 +101,7 @@ class sfeTkIBus
         @retval sfeTkError_t kSTkErrOk on successful execution
 
     */
-    virtual sfeTkError_t write16BitRegisterRegion(uint16_t devReg, const uint8_t *data, size_t length) = 0;
+    virtual sfeTkError_t write16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t length) = 0;
 
 
     /*--------------------------------------------------------------------------

--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -101,7 +101,7 @@ class sfeTkIBus
         @retval sfeTkError_t kSTkErrOk on successful execution
 
     */
-    virtual sfeTkError_t write16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t length) = 0;
+    virtual sfeTkError_t writeRegister16Region(uint16_t devReg, uint8_t *data, size_t length) = 0;
 
 
     /*--------------------------------------------------------------------------
@@ -150,7 +150,7 @@ class sfeTkIBus
         @retval int returns kSTkErrOk on success, or kSTkErrFail code
 
     */
-    virtual sfeTkError_t read16BitRegisterRegion(uint16_t reg, uint8_t *data, size_t numBytes, size_t *readBytes = nullptr) = 0;
+    virtual sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes, size_t *readBytes = nullptr) = 0;
 
 };
 

--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -150,7 +150,7 @@ class sfeTkIBus
         @retval int returns kSTkErrOk on success, or kSTkErrFail code
 
     */
-    virtual sfeTkError_t read16BitRegisterRegion(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes) = 0;
+    virtual sfeTkError_t read16BitRegisterRegion(uint16_t reg, uint8_t *data, size_t numBytes, size_t *readBytes = nullptr) = 0;
 
 };
 

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -301,7 +301,7 @@ sfeTkError_t sfeTkArdI2C::readRegisterRegion(uint8_t devReg, uint8_t *data, size
 //
 // Returns the number of bytes read, < 0 is an error
 //
-sfeTkError_t sfeTkArdI2C::read16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t numBytes, size_t &readBytes)
+sfeTkError_t sfeTkArdI2C::read16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t numBytes, size_t *readBytes)
 {
 
     // got port
@@ -312,7 +312,10 @@ sfeTkError_t sfeTkArdI2C::read16BitRegisterRegion(uint16_t devReg, uint8_t *data
     if (!data)
         return kSTkErrBusNullBuffer;
   
-    readBytes = 0;
+    if(readBytes != nullptr)
+    {
+        readBytes = 0;
+    }
 
     uint16_t nOrig = numBytes; // original number of bytes.
     uint8_t nChunk;
@@ -354,7 +357,14 @@ sfeTkError_t sfeTkArdI2C::read16BitRegisterRegion(uint16_t devReg, uint8_t *data
 
     } // end while
 
-    readBytes = nOrig - numBytes; // Bytes read.
+    if(readBytes != nullptr)
+    {
+        *readBytes = nOrig - numBytes; // Bytes read.
 
-    return (readBytes == nOrig) ? kSTkErrOk : kSTkErrBusUnderRead; // Success
+        return (*readBytes == nOrig) ? kSTkErrOk : kSTkErrBusUnderRead; // Success
+    }
+    else
+    {
+        return (numBytes == 0) ? kSTkErrOk : kSTkErrBusUnderRead; // Success
+    }
 }

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -156,6 +156,27 @@ sfeTkError_t sfeTkArdI2C::writeRegisterRegion(uint8_t devReg, const uint8_t *dat
 }
 
 //---------------------------------------------------------------------------------
+// write16BitRegisterRegion()
+//
+// Writes an array of bytes to a given 16-bit register on the target address
+//
+// Returns the number of bytes written, < 0 is an error
+//
+sfeTkError_t sfeTkArdI2C::write16BitRegisterRegion(uint16_t devReg, const uint8_t *data, size_t length)
+{
+    if (!_i2cPort)
+        return kSTkErrBusNotInit;
+
+    _i2cPort->beginTransmission(address());
+    _i2cPort->write((devReg >> 8) & 0xff);
+    _i2cPort->write(devReg & 0xff);
+    _i2cPort->write(data, (int)length);
+
+    return _i2cPort->endTransmission() ? kSTkErrFail : kSTkErrOk;
+}
+
+
+//---------------------------------------------------------------------------------
 // readRegisterByte()
 //
 // Reads a byte to a given register.
@@ -239,6 +260,74 @@ sfeTkError_t sfeTkArdI2C::readRegisterRegion(uint8_t devReg, uint8_t *data, size
             _i2cPort->beginTransmission(address());
 
             _i2cPort->write(devReg);
+
+            if (_i2cPort->endTransmission(stop()) != 0)
+                return kSTkErrFail; // error with the end transmission
+
+            bFirstInter = false;
+        }
+
+        // We're chunking in data - keeping the max chunk to kMaxI2CBufferLength
+        nChunk = numBytes > _bufferChunkSize ? _bufferChunkSize : numBytes;
+
+        // Request the bytes. If this is the last chunk, always send a stop
+        nReturned = _i2cPort->requestFrom((int)address(), (int)nChunk, (int)(nChunk == numBytes ? true : stop()));
+
+        // No data returned, no dice
+        if (nReturned == 0)
+            return kSTkErrBusUnderRead; // error
+
+        // Copy the retrieved data chunk to the current index in the data segment
+        for (i = 0; i < nReturned; i++)
+            *data++ = _i2cPort->read();
+
+        // Decrement the amount of data received from the overall data request amount
+        numBytes = numBytes - nReturned;
+
+    } // end while
+
+    readBytes = nOrig - numBytes; // Bytes read.
+
+    return (readBytes == nOrig) ? kSTkErrOk : kSTkErrBusUnderRead; // Success
+}
+
+
+
+
+//---------------------------------------------------------------------------------
+// read16BitRegisterRegion()
+//
+// Reads an array of bytes to a given 16-bit register on the target address
+//
+// Returns the number of bytes read, < 0 is an error
+//
+sfeTkError_t sfeTkArdI2C::read16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t numBytes, size_t &readBytes)
+{
+
+    // got port
+    if (!_i2cPort)
+        return kSTkErrBusNotInit;
+
+    // Buffer valid?
+    if (!data)
+        return kSTkErrBusNullBuffer;
+  
+    readBytes = 0;
+
+    uint16_t nOrig = numBytes; // original number of bytes.
+    uint8_t nChunk;
+    uint16_t nReturned;
+    uint16_t i;              // counter in loop
+    bool bFirstInter = true; // Flag for first iteration - used to send devRegister
+
+    while (numBytes > 0)
+    {
+        if (bFirstInter)
+        {
+            _i2cPort->beginTransmission(address());
+
+            _i2cPort->write((devReg >> 8) & 0xff);
+            _i2cPort->write(devReg & 0xff);
 
             if (_i2cPort->endTransmission(stop()) != 0)
                 return kSTkErrFail; // error with the end transmission

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -162,7 +162,9 @@ sfeTkError_t sfeTkArdI2C::writeRegisterRegion(uint8_t devReg, const uint8_t *dat
 //
 // Returns the number of bytes written, < 0 is an error
 //
-sfeTkError_t sfeTkArdI2C::write16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t length)
+//sfeTkError_t sfeTkArdI2C::write16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t length)
+sfeTkError_t sfeTkArdI2C::writeRegister16Region(uint16_t devReg, uint8_t *data, size_t length)
+
 {
     if (!_i2cPort)
         return kSTkErrBusNotInit;
@@ -302,7 +304,8 @@ sfeTkError_t sfeTkArdI2C::readRegisterRegion(uint8_t devReg, uint8_t *data, size
 //
 // Returns the number of bytes read, < 0 is an error
 //
-sfeTkError_t sfeTkArdI2C::read16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t numBytes, size_t *readBytes)
+//sfeTkError_t sfeTkArdI2C::read16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t numBytes, size_t *readBytes)
+sfeTkError_t sfeTkArdI2C::readRegister16Region(uint16_t devReg, uint8_t *data, size_t numBytes, size_t *readBytes)
 {
 
     // got port

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -162,19 +162,20 @@ sfeTkError_t sfeTkArdI2C::writeRegisterRegion(uint8_t devReg, const uint8_t *dat
 //
 // Returns the number of bytes written, < 0 is an error
 //
-sfeTkError_t sfeTkArdI2C::write16BitRegisterRegion(uint16_t devReg, const uint8_t *data, size_t length)
+sfeTkError_t sfeTkArdI2C::write16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t length)
 {
     if (!_i2cPort)
         return kSTkErrBusNotInit;
-
     _i2cPort->beginTransmission(address());
     _i2cPort->write((devReg >> 8) & 0xff);
     _i2cPort->write(devReg & 0xff);
-    _i2cPort->write(data, (int)length);
+    for(int i = 0; i < length; i++)
+    {
+        _i2cPort->write(data[i]);
+    }
 
     return _i2cPort->endTransmission() ? kSTkErrFail : kSTkErrOk;
 }
-
 
 //---------------------------------------------------------------------------------
 // readRegisterByte()

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -124,7 +124,7 @@ sfeTkError_t sfeTkArdI2C::writeRegisterByte(uint8_t devReg, uint8_t dataToWrite)
 //---------------------------------------------------------------------------------
 // writeRegisterWord()
 //
-// Writes a world to a given register.
+// Writes a word to a given register.
 //
 // Returns true on success, false on failure
 //
@@ -136,6 +136,14 @@ sfeTkError_t sfeTkArdI2C::writeRegisterWord(uint8_t devReg, uint16_t dataToWrite
     return writeRegisterRegion(devReg, (uint8_t *)&dataToWrite, sizeof(uint16_t));
 }
 
+//---------------------------------------------------------------------------------
+// writeRegisterRegionAddress()
+//
+// Writes an array of bytes of specified length to a given register on the 
+//  target address
+//
+// Returns the number of bytes written, < 0 is an error
+//
 sfeTkError_t sfeTkArdI2C::writeRegisterRegionAddress(uint8_t *devReg, size_t regLength, const uint8_t *data, size_t length)
 {
     if (!_i2cPort)
@@ -167,26 +175,19 @@ sfeTkError_t sfeTkArdI2C::writeRegisterRegion(uint8_t devReg, const uint8_t *dat
 //
 // Returns the number of bytes written, < 0 is an error
 //
-// sfeTkError_t sfeTkArdI2C::writeRegister16Region(uint16_t devReg, uint8_t *data, size_t length)
-// {
-//     if (!_i2cPort)
-//         return kSTkErrBusNotInit;
-//     _i2cPort->beginTransmission(address());
-//     _i2cPort->write((devReg >> 8) & 0xff);
-//     _i2cPort->write(devReg & 0xff);
-//     for(int i = 0; i < length; i++)
-//     {
-//         _i2cPort->write(data[i]);
-//     }
-//     return _i2cPort->endTransmission() ? kSTkErrFail : kSTkErrOk;
-// }
-
 sfeTkError_t sfeTkArdI2C::writeRegister16Region(uint16_t devReg, uint8_t *data, size_t length)
 {
     devReg = ((devReg << 8) & 0xff00) | ((devReg >> 8) & 0x00ff);
     return writeRegisterRegionAddress((uint8_t*)&devReg, 2, data, length);
 }
 
+//---------------------------------------------------------------------------------
+// readRegisterRegionAnyAddress()
+//
+// Reads an array of bytes to a register on the target address
+//
+// Returns the number of bytes written, < 0 is an error
+//
 sfeTkError_t sfeTkArdI2C::readRegisterRegionAnyAddress(uint8_t *devReg, size_t regLength, uint8_t *data, size_t numBytes, size_t &readBytes)
 {
 
@@ -281,10 +282,11 @@ sfeTkError_t sfeTkArdI2C::readRegisterByte(uint8_t devReg, uint8_t &dataToRead)
 
     return (nData == sizeof(uint8_t) ? kSTkErrOk : kSTkErrFail);
 }
+
 //---------------------------------------------------------------------------------
 // readRegisterWord()
 //
-// Reads a world to a given register.
+// Reads a word to a given register.
 //
 // Returns true on success, false on failure
 //
@@ -321,8 +323,6 @@ sfeTkError_t sfeTkArdI2C::readRegisterRegion(uint8_t devReg, uint8_t *data, size
 sfeTkError_t sfeTkArdI2C::readRegister16Region(uint16_t devReg, uint8_t *data, size_t numBytes)
 {
     size_t readBytes = 0;
-    devReg = ((devReg << 8) & 0xff00) | ((devReg >> 8) & 0x00ff);
-//     _i2cPort->write((devReg >> 8) & 0xff);
-//     _i2cPort->write(devReg & 0xff);
+    devReg = ((devReg << 8) & 0xff00) | ((devReg >> 8) & 0x00ff); 
     return readRegisterRegionAnyAddress((uint8_t*)&devReg, 2, data, numBytes, readBytes);
 }

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -213,9 +213,6 @@ sfeTkError_t sfeTkArdI2C::readRegisterRegionAnyAddress(uint8_t *devReg, size_t r
         {
             _i2cPort->beginTransmission(address());
 
-            // uint16_t *foo = (uint16_t*)devReg;
-            // _i2cPort->write((*foo >> 8) & 0xff);
-            // _i2cPort->write(*foo & 0xff);
             _i2cPort->write(devReg, regLength);
 
             if (_i2cPort->endTransmission(stop()) != 0)

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -200,8 +200,8 @@ class sfeTkArdI2C : public sfeTkII2C
 
         @retval int returns kSTkErrOk on success, or kSTkErrFail code
 
-    */
-    sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes, size_t *readBytes = nullptr);
+    */ 
+    sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes);
 
     // Buffer size chunk getter/setter
     /*--------------------------------------------------------------------------
@@ -237,6 +237,10 @@ class sfeTkArdI2C : public sfeTkII2C
     TwoWire *_i2cPort;
 
   private:
+sfeTkError_t writeRegisterRegionAddress(uint8_t *devReg, size_t regLength, const uint8_t *data, size_t length);
+
+sfeTkError_t readRegisterRegionAnyAddress(uint8_t *devReg, size_t regLength, uint8_t *data, size_t numBytes, size_t &readBytes);
+
     static constexpr size_t kDefaultBufferChunk = 32;
 
     // the I2C buffer chunker size

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -138,6 +138,19 @@ class sfeTkArdI2C : public sfeTkII2C
     virtual sfeTkError_t writeRegisterRegion(uint8_t devReg, const uint8_t *data, size_t length);
 
     /*--------------------------------------------------------------------------
+        @brief Writes a number of bytes starting at the given register's 16-bit address.
+
+        @param devAddr The device's 16-bit address/pin
+        param devReg The device's register's address.
+        @param data Data to write.
+
+        @retval sfeTkError_t kSTkErrOk on successful execution
+
+    */
+    sfeTkError_t write16BitRegisterRegion(uint16_t devReg, const uint8_t *data, size_t length);
+
+
+    /*--------------------------------------------------------------------------
         @brief Reads a byte of data from the given register.
 
         @note sfeTkIBus interface method
@@ -176,6 +189,19 @@ class sfeTkArdI2C : public sfeTkII2C
         @retval kSTkErrOk on success
     */
     sfeTkError_t readRegisterRegion(uint8_t devReg, uint8_t *data, size_t numBytes, size_t &readBytes);
+
+    /*--------------------------------------------------------------------------
+        @brief Reads a block of data from the given 16-bit register address.
+
+        @param reg The device's 16 bit register's address.
+        @param data Data to write.
+        @param numBytes - length of data
+        @param[out] readBytes - number of bytes read
+
+        @retval int returns kSTkErrOk on success, or kSTkErrFail code
+
+    */
+    sfeTkError_t read16BitRegisterRegion(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes);
 
     // Buffer size chunk getter/setter
     /*--------------------------------------------------------------------------

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -147,7 +147,7 @@ class sfeTkArdI2C : public sfeTkII2C
         @retval sfeTkError_t kSTkErrOk on successful execution
 
     */
-    sfeTkError_t write16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t length);
+    sfeTkError_t writeRegister16Region(uint16_t devReg, uint8_t *data, size_t length);
 
 
     /*--------------------------------------------------------------------------
@@ -201,7 +201,7 @@ class sfeTkArdI2C : public sfeTkII2C
         @retval int returns kSTkErrOk on success, or kSTkErrFail code
 
     */
-    sfeTkError_t read16BitRegisterRegion(uint16_t reg, uint8_t *data, size_t numBytes, size_t *readBytes = nullptr);
+    sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes, size_t *readBytes = nullptr);
 
     // Buffer size chunk getter/setter
     /*--------------------------------------------------------------------------

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -147,7 +147,7 @@ class sfeTkArdI2C : public sfeTkII2C
         @retval sfeTkError_t kSTkErrOk on successful execution
 
     */
-    sfeTkError_t write16BitRegisterRegion(uint16_t devReg, const uint8_t *data, size_t length);
+    sfeTkError_t write16BitRegisterRegion(uint16_t devReg, uint8_t *data, size_t length);
 
 
     /*--------------------------------------------------------------------------

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -201,7 +201,7 @@ class sfeTkArdI2C : public sfeTkII2C
         @retval int returns kSTkErrOk on success, or kSTkErrFail code
 
     */
-    sfeTkError_t read16BitRegisterRegion(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes);
+    sfeTkError_t read16BitRegisterRegion(uint16_t reg, uint8_t *data, size_t numBytes, size_t *readBytes = nullptr);
 
     // Buffer size chunk getter/setter
     /*--------------------------------------------------------------------------

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -237,9 +237,9 @@ class sfeTkArdI2C : public sfeTkII2C
     TwoWire *_i2cPort;
 
   private:
-sfeTkError_t writeRegisterRegionAddress(uint8_t *devReg, size_t regLength, const uint8_t *data, size_t length);
+    sfeTkError_t writeRegisterRegionAddress(uint8_t *devReg, size_t regLength, const uint8_t *data, size_t length);
 
-sfeTkError_t readRegisterRegionAnyAddress(uint8_t *devReg, size_t regLength, uint8_t *data, size_t numBytes, size_t &readBytes);
+    sfeTkError_t readRegisterRegionAnyAddress(uint8_t *devReg, size_t regLength, uint8_t *data, size_t numBytes, size_t &readBytes);
 
     static constexpr size_t kDefaultBufferChunk = 32;
 

--- a/src/sfeTkArdSPI.h
+++ b/src/sfeTkArdSPI.h
@@ -123,6 +123,17 @@ class sfeTkArdSPI : public sfeTkISPI
     virtual sfeTkError_t writeRegisterRegion(uint8_t devReg, const uint8_t *data, size_t length);
 
     /*--------------------------------------------------------------------------
+        @brief Writes a number of bytes starting at the given register's address.
+        @note This method is virtual to allow it to be overridden to support a device that requires a unique impl
+
+        @param devReg The device's register's address.
+        @param data Data to write.
+
+        @retval sfeTkError_t - kSTkErrOk on success
+    */
+    virtual sfeTkError_t writeRegister16Region(uint16_t devReg, const uint8_t *data, size_t length);
+
+    /*--------------------------------------------------------------------------
         @brief Read a single byte from the given register
 
         @param devReg The device's register's address.
@@ -154,6 +165,20 @@ class sfeTkArdSPI : public sfeTkISPI
         @retval sfeTkError_t - true on success
     */
     virtual sfeTkError_t readRegisterRegion(uint8_t reg, uint8_t *data, size_t numBytes, size_t &readBytes);
+
+    /*--------------------------------------------------------------------------
+        @brief Reads a block of data from the given register.
+        @note This method is virtual to allow it to be overridden to support a device that requires a unique impl
+
+        @param devReg The device's register's 16 bit address.
+        @param data Data to write.
+        @param numBytes - length of data
+        @param[out] readBytes - Number of bytes read
+
+        @retval sfeTkError_t - true on success
+    */
+    virtual sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes);
+
 
   protected:
     // note: The instance data is protected, allowing access if a sub-class is


### PR DESCRIPTION
This will add support for 16-bit register addresses for SPI and I2C implementations. This code has been tested on the XM125 16-bit address, 32-bit registers. The specific functions added for I2C and SPI: 

- readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes) 
- writeRegister16Region(uint16_t devReg, uint8_t *data, size_t length)