### PR TITLE
Add writeWord writeBlock

### DIFF
--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -111,7 +111,7 @@ class sfeTkIBus
      *  @retval sfeTkError_t -  kSTkErrOk on successful execution.
      *
      */
-    virtual sfeTkError_t writeBlock(const uint8_t *data, size_t length) = 0;
+    virtual sfeTkError_t writeRegion(const uint8_t *data, size_t length) = 0;
 
     /**--------------------------------------------------------------------------
      *  @brief Write a single byte to the given register
@@ -123,45 +123,6 @@ class sfeTkIBus
      *
      */
     virtual sfeTkError_t writeRegisterByte(uint8_t devReg, uint8_t data) = 0;
-
-    /**
-        @brief Reads a byte of data from the device.
-
-        @note sfeTkIBus interface method
-
-        @param dataToWrite The data to write to the device. 
-        @param[out] data Data to read.
-
-        @retval  kStkErrOk on success
-    */
-    virtual sfeTkError_t readByte(uint8_t dataToWrite, uint8_t &data) = 0; 
-
-    /**
-        @brief Reads a word of data from the device.
-
-        @note sfeTkIBus interface method
-
-        @param dataToWrite The data to write to the device.
-        @param[out] data Data to read.
-
-        @retval kSTkErrOk on success
-    */
-    virtual sfeTkError_t readWord(uint8_t dataToWrite, uint16_t &data) = 0;
-
-    /**
-        @brief Reads a block of data from the device.
-
-        @note sfeTkIBus interface method
-
-        @param dataToWrite The data to write to the device.
-        @param[out] data Data buffer to read into
-        @param numBytes Number of bytes to read/length of data buffer
-        @param[out] readBytes - Number of bytes read
-
-
-        @retval kSTkErrOk on success
-    */
-    virtual sfeTkError_t readBlock(uint8_t dataToWrite, uint8_t *data, size_t numBytes, size_t &readBytes) = 0; 
 
     /**--------------------------------------------------------------------------
      * @brief Write a single word (16 bit) to the given register

--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -87,13 +87,31 @@ class sfeTkIBus
 {
   public:
     /**--------------------------------------------------------------------------
-     *  @brief Write a single byte to the device*
+     *  @brief Send a single byte to the device*
      *  @param data Data to write.
      *
      *  @retval sfeTkError_t -  kSTkErrOk on successful execution.
      *
      */
     virtual sfeTkError_t writeByte(uint8_t data) = 0;
+
+    /**--------------------------------------------------------------------------
+     *  @brief Send a word to the device. 
+     *  @param data Data to write.
+     *
+     *  @retval sfeTkError_t -  kSTkErrOk on successful execution.
+     *
+     */
+    virtual sfeTkError_t writeWord(uint16_t data) = 0;
+
+    /**--------------------------------------------------------------------------
+     *  @brief Send an array of data to the device.
+     *  @param data Data to write.
+     *
+     *  @retval sfeTkError_t -  kSTkErrOk on successful execution.
+     *
+     */
+    virtual sfeTkError_t writeBlock(const uint8_t *data, size_t length) = 0;
 
     /**--------------------------------------------------------------------------
      *  @brief Write a single byte to the given register

--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -124,6 +124,45 @@ class sfeTkIBus
      */
     virtual sfeTkError_t writeRegisterByte(uint8_t devReg, uint8_t data) = 0;
 
+    /**
+        @brief Reads a byte of data from the device.
+
+        @note sfeTkIBus interface method
+
+        @param dataToWrite The data to write to the device. 
+        @param[out] data Data to read.
+
+        @retval  kStkErrOk on success
+    */
+    virtual sfeTkError_t readByte(uint8_t dataToWrite, uint8_t &data) = 0; 
+
+    /**
+        @brief Reads a word of data from the device.
+
+        @note sfeTkIBus interface method
+
+        @param dataToWrite The data to write to the device.
+        @param[out] data Data to read.
+
+        @retval kSTkErrOk on success
+    */
+    virtual sfeTkError_t readWord(uint8_t dataToWrite, uint16_t &data) = 0;
+
+    /**
+        @brief Reads a block of data from the device.
+
+        @note sfeTkIBus interface method
+
+        @param dataToWrite The data to write to the device.
+        @param[out] data Data buffer to read into
+        @param numBytes Number of bytes to read/length of data buffer
+        @param[out] readBytes - Number of bytes read
+
+
+        @retval kSTkErrOk on success
+    */
+    virtual sfeTkError_t readBlock(uint8_t dataToWrite, uint8_t *data, size_t numBytes, size_t &readBytes) = 0; 
+
     /**--------------------------------------------------------------------------
      * @brief Write a single word (16 bit) to the given register
      *

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -22,6 +22,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 #include "sfeTkArdI2C.h"
+#include <cstddef>
+#include <cstdint>
 
 //---------------------------------------------------------------------------------
 // init()
@@ -87,7 +89,7 @@ sfeTkError_t sfeTkArdI2C::ping()
 //---------------------------------------------------------------------------------
 // writeByte()
 //
-// Sends a single byte to the device.
+// Writes a single byte to the device, without indexing to a register.
 //
 // Returns true on success, false on failure
 //
@@ -105,7 +107,7 @@ sfeTkError_t sfeTkArdI2C::writeByte(uint8_t dataToWrite)
 //---------------------------------------------------------------------------------
 // writeWord()
 //
-// Sends a word to the device.
+// Writes a word to the device, without indexing to a register.
 //
 // Returns true on success, false on failure
 //
@@ -120,13 +122,12 @@ sfeTkError_t sfeTkArdI2C::writeWord(uint16_t dataToWrite)
 //---------------------------------------------------------------------------------
 // writeBlock()
 //
-// Sends an array of data to the device.
+// Writes a word to the device, without indexing to a register.
 //
 // Returns true on success, false on failure
 //
 sfeTkError_t sfeTkArdI2C::writeBlock(const uint8_t *data, size_t length)
 {
-    int nData = 0; 
     if (!_i2cPort)
         return kSTkErrBusNotInit;
 
@@ -216,6 +217,121 @@ sfeTkError_t sfeTkArdI2C::writeRegister16Region(uint16_t devReg, const uint8_t *
 {
     devReg = ((devReg << 8) & 0xff00) | ((devReg >> 8) & 0x00ff);
     return writeRegisterRegionAddress((uint8_t *)&devReg, 2, data, length);
+}
+
+//---------------------------------------------------------------------------------
+// readByte()
+//
+// Reads a byte from the device, without indexing to a register.
+//
+// Returns true on success, false on failure
+//
+sfeTkError_t sfeTkArdI2C::readByte(uint8_t dataToWrite, uint8_t &dataToRead)
+{
+    if (!_i2cPort)
+        return kSTkErrBusNotInit;
+
+    // Return value
+    uint8_t result = 0;
+
+    int nData = 0;
+
+    _i2cPort->beginTransmission(address());
+    _i2cPort->write(dataToWrite);
+    _i2cPort->endTransmission(stop());
+    _i2cPort->requestFrom(address(), (uint8_t)1);
+
+    while (_i2cPort->available()) // slave may send less than requested
+    {
+        result = _i2cPort->read(); // receive a byte as a proper uint8_t
+        nData++;
+    }
+
+    if (nData == sizeof(uint8_t)) // Only update outputPointer if a single byte was returned
+        dataToRead = result;
+
+    return (nData == sizeof(uint8_t) ? kSTkErrOk : kSTkErrFail);
+}
+
+
+//---------------------------------------------------------------------------------
+// readWord()
+//
+// Reads a word from the device, without indexing to a register.
+//
+// Returns true on success, false on failure
+//
+sfeTkError_t sfeTkArdI2C::readWord(uint8_t dataToWrite, uint16_t &dataToRead)
+{
+    if (!_i2cPort)
+        return kSTkErrBusNotInit;
+
+    size_t nRead;
+    sfeTkError_t retval = readBlock(dataToWrite, (uint8_t *)&dataToRead, sizeof(uint16_t), nRead);
+
+    return (retval == kSTkErrOk && nRead == sizeof(uint16_t) ? kSTkErrOk : retval);
+}
+
+//---------------------------------------------------------------------------------
+// readBlock()
+//
+// Reads a block of data from the device, without indexing to a register.
+//
+// Returns the number of bytes written, < 0 is an error
+//
+sfeTkError_t sfeTkArdI2C::readBlock(uint8_t dataToWrite, uint8_t *data, size_t numBytes, size_t &readBytes)
+{
+
+    // got port
+    if (!_i2cPort)
+        return kSTkErrBusNotInit;
+
+    // Buffer valid?
+    if (!data)
+        return kSTkErrBusNullBuffer;
+
+    readBytes = 0;
+
+    uint16_t nOrig = numBytes; // original number of bytes.
+    uint8_t nChunk;
+    uint16_t nReturned;
+    uint16_t i;              // counter in loop
+    bool bFirstInter = true; // Flag for first iteration - used to send devRegister
+
+    while (numBytes > 0)
+    {
+        if (bFirstInter)
+        {
+            _i2cPort->beginTransmission(address());
+            _i2cPort->write(dataToWrite);
+            if (_i2cPort->endTransmission(stop()) != 0)
+                return kSTkErrFail; // error with the end transmission
+
+            bFirstInter = false;
+        }
+
+        // We're chunking in data - keeping the max chunk to kMaxI2CBufferLength
+        nChunk = numBytes > _bufferChunkSize ? _bufferChunkSize : numBytes;
+
+        // Request the bytes. If this is the last chunk, always send a stop
+        nReturned = _i2cPort->requestFrom((int)address(), (int)nChunk, (int)(nChunk == numBytes ? true : stop()));
+
+        // No data returned, no dice
+        if (nReturned == 0)
+            return kSTkErrBusUnderRead; // error
+
+        // Copy the retrieved data chunk to the current index in the data segment
+        for (i = 0; i < nReturned; i++)
+            *data++ = _i2cPort->read();
+
+        // Decrement the amount of data received from the overall data request amount
+        numBytes = numBytes - nReturned;
+
+    } // end while
+
+    readBytes = nOrig - numBytes; // Bytes read.
+
+    return (readBytes == nOrig) ? kSTkErrOk : kSTkErrBusUnderRead; // Success
 }
 
 //---------------------------------------------------------------------------------

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 #include "sfeTkArdI2C.h"
+#include <cstdint>
 
 //---------------------------------------------------------------------------------
 // init()
@@ -87,7 +88,7 @@ sfeTkError_t sfeTkArdI2C::ping()
 //---------------------------------------------------------------------------------
 // writeByte()
 //
-// Writes a single byte to the device.
+// Sends a single byte to the device.
 //
 // Returns true on success, false on failure
 //
@@ -99,6 +100,41 @@ sfeTkError_t sfeTkArdI2C::writeByte(uint8_t dataToWrite)
     // do the Arduino I2C work
     _i2cPort->beginTransmission(address());
     _i2cPort->write(dataToWrite);
+    return _i2cPort->endTransmission() == 0 ? kSTkErrOk : kSTkErrFail;
+}
+
+//---------------------------------------------------------------------------------
+// writeWord()
+//
+// Sends a word to the device.
+//
+// Returns true on success, false on failure
+//
+sfeTkError_t sfeTkArdI2C::writeWord(uint16_t dataToWrite)
+{
+    if (!_i2cPort)
+        return kSTkErrBusNotInit;
+
+    return writeBlock((uint8_t *)&dataToWrite, sizeof(uint16_t));
+}
+
+//---------------------------------------------------------------------------------
+// writeBlock()
+//
+// Sends an array of data to the device.
+//
+// Returns true on success, false on failure
+//
+sfeTkError_t sfeTkArdI2C::writeBlock(const uint8_t *dataToWrite, size_t length)
+{
+    int nData = 0; 
+    if (!_i2cPort)
+        return kSTkErrBusNotInit;
+
+    // do the Arduino I2C work
+    _i2cPort->beginTransmission(address());
+    _i2cPort->write(data, (int)length);
+
     return _i2cPort->endTransmission() == 0 ? kSTkErrOk : kSTkErrFail;
 }
 

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -128,9 +128,6 @@ sfeTkError_t sfeTkArdI2C::writeWord(uint16_t dataToWrite)
 //
 sfeTkError_t sfeTkArdI2C::writeRegion(const uint8_t *data, size_t length)
 {
-    if (!_i2cPort)
-        return kSTkErrBusNotInit;
-    // do the Arduino I2C work
     return writeRegisterRegionAddress(nullptr, 0, data, length) == 0 ? kSTkErrOk : kSTkErrFail;
 }
 

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -125,7 +125,7 @@ sfeTkError_t sfeTkArdI2C::writeWord(uint16_t dataToWrite)
 //
 // Returns true on success, false on failure
 //
-sfeTkError_t sfeTkArdI2C::writeBlock(const uint8_t *dataToWrite, size_t length)
+sfeTkError_t sfeTkArdI2C::writeBlock(const uint8_t *data, size_t length)
 {
     int nData = 0; 
     if (!_i2cPort)

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -22,7 +22,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 #include "sfeTkArdI2C.h"
-#include <cstdint>
 
 //---------------------------------------------------------------------------------
 // init()

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -136,7 +136,7 @@ class sfeTkArdI2C : public sfeTkII2C
 
         @retval returns  kStkErrOk on success
     */
-    sfeTkError_t writeBlock(const uint8_t *data, size_t length);
+    sfeTkError_t writeRegion(const uint8_t *data, size_t length);
 
     /**
         @brief Write a single byte to the given register
@@ -185,45 +185,6 @@ class sfeTkArdI2C : public sfeTkII2C
 
     */
     sfeTkError_t writeRegister16Region(uint16_t devReg, const uint8_t *data, size_t length);
-
-    /**
-        @brief Reads a byte of data from the device.
-
-        @note sfeTkIBus interface method
-
-        @param dataToWrite The data to write to the device.
-        @param[out] data Data to read.
-
-        @retval  kStkErrOk on success
-    */
-    sfeTkError_t readByte(uint8_t dataToWrite, uint8_t &data);
-
-    /**
-        @brief Reads a word of data from the device.
-
-        @note sfeTkIBus interface method
-
-        @param dataToWrite The data to write to the device.
-        @param[out] data Data to read.
-
-        @retval kSTkErrOk on success
-    */
-    sfeTkError_t readWord(uint8_t dataToWrite, uint16_t &data);
-
-    /**
-        @brief Reads a block of data from the device.
-
-        @note sfeTkIBus interface method
-
-        @param dataToWrite The data to write to the device.
-        @param[out] data Data buffer to read into
-        @param numBytes Number of bytes to read/length of data buffer
-        @param[out] readBytes - Number of bytes read
-
-
-        @retval kSTkErrOk on success
-    */
-    sfeTkError_t readBlock(uint8_t dataToWrite, uint8_t *data, size_t numBytes, size_t &readBytes);
 
     /**
         @brief Reads a byte of data from the given register.

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -136,7 +136,7 @@ class sfeTkArdI2C : public sfeTkII2C
 
         @retval returns  kStkErrOk on success
     */
-    sfeTkError_t writeBlock(const uint8_t *data);
+    sfeTkError_t writeBlock(const uint8_t *data, size_t length);
 
     /**
         @brief Write a single byte to the given register

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -187,6 +187,45 @@ class sfeTkArdI2C : public sfeTkII2C
     sfeTkError_t writeRegister16Region(uint16_t devReg, const uint8_t *data, size_t length);
 
     /**
+        @brief Reads a byte of data from the device.
+
+        @note sfeTkIBus interface method
+
+        @param dataToWrite The data to write to the device.
+        @param[out] data Data to read.
+
+        @retval  kStkErrOk on success
+    */
+    sfeTkError_t readByte(uint8_t dataToWrite, uint8_t &data);
+
+    /**
+        @brief Reads a word of data from the device.
+
+        @note sfeTkIBus interface method
+
+        @param dataToWrite The data to write to the device.
+        @param[out] data Data to read.
+
+        @retval kSTkErrOk on success
+    */
+    sfeTkError_t readWord(uint8_t dataToWrite, uint16_t &data);
+
+    /**
+        @brief Reads a block of data from the device.
+
+        @note sfeTkIBus interface method
+
+        @param dataToWrite The data to write to the device.
+        @param[out] data Data buffer to read into
+        @param numBytes Number of bytes to read/length of data buffer
+        @param[out] readBytes - Number of bytes read
+
+
+        @retval kSTkErrOk on success
+    */
+    sfeTkError_t readBlock(uint8_t dataToWrite, uint8_t *data, size_t numBytes, size_t &readBytes);
+
+    /**
         @brief Reads a byte of data from the given register.
 
         @note sfeTkIBus interface method

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -109,7 +109,7 @@ class sfeTkArdI2C : public sfeTkII2C
     sfeTkError_t ping();
 
     /**
-        @brief Write a single byte to the device
+        @brief Sends a single byte to the device
         @note sfeTkIBus interface method
 
         @param data Data to write.
@@ -117,6 +117,26 @@ class sfeTkArdI2C : public sfeTkII2C
         @retval returns  kStkErrOk on success
     */
     sfeTkError_t writeByte(uint8_t data);
+
+    /**
+        @brief Sends a word to the device.
+        @note sfeTkIBus interface method
+
+        @param data Data to write.
+
+        @retval returns  kStkErrOk on success
+    */
+    sfeTkError_t writeWord(uint16_t data);
+
+    /**
+        @brief Sends a block of data to the device.
+        @note sfeTkIBus interface method
+
+        @param data Data to write.
+
+        @retval returns  kStkErrOk on success
+    */
+    sfeTkError_t writeBlock(const uint8_t *data);
 
     /**
         @brief Write a single byte to the given register

--- a/src/sfeTkArdSPI.cpp
+++ b/src/sfeTkArdSPI.cpp
@@ -82,7 +82,7 @@ sfeTkError_t sfeTkArdSPI::init(bool bInit)
 }
 
 //---------------------------------------------------------------------------------
-// writeRegisterByte()
+// writeByte()
 //
 // Writes a single byte to the device.
 //
@@ -100,6 +100,46 @@ sfeTkError_t sfeTkArdSPI::writeByte(uint8_t dataToWrite)
     digitalWrite(cs(), LOW);
 
     _spiPort->transfer(dataToWrite);
+
+    // End communication
+    digitalWrite(cs(), HIGH);
+    _spiPort->endTransaction();
+
+    return kSTkErrOk;
+}
+
+//---------------------------------------------------------------------------------
+// writeWord()
+//
+// Writes a word to the device without indexing to a register.
+//
+// Returns kSTkErrOk on success
+//
+sfeTkError_t sfeTkArdSPI::writeWord(uint16_t dataToWrite)
+{
+    return writeRegion((uint8_t *)&dataToWrite, sizeof(uint8_t)) > 0;
+}
+
+
+//---------------------------------------------------------------------------------
+// writeRegion()
+//
+// Writes an array of data to the device without indexing to a register.
+//
+// Returns kSTkErrOk on success
+//
+sfeTkError_t sfeTkArdSPI::writeRegion(const uint8_t *dataToWrite, size_t length)
+{
+
+    if (!_spiPort)
+        return kSTkErrBusNotInit;
+
+    _spiPort->beginTransaction(_sfeSPISettings);
+    // Signal communication start
+    digitalWrite(cs(), LOW);
+
+    for (size_t i = 0; i < length; i++)
+        _spiPort->transfer(*dataToWrite++);
 
     // End communication
     digitalWrite(cs(), HIGH);
@@ -164,6 +204,7 @@ sfeTkError_t sfeTkArdSPI::writeRegisterRegion(uint8_t devReg, const uint8_t *dat
 
     // Signal communication start
     digitalWrite(cs(), LOW);
+
     _spiPort->transfer(devReg);
 
     for (size_t i = 0; i < length; i++)

--- a/src/sfeTkArdSPI.h
+++ b/src/sfeTkArdSPI.h
@@ -116,6 +116,25 @@ class sfeTkArdSPI : public sfeTkISPI
     sfeTkError_t writeByte(uint8_t data);
 
     /**
+        @brief Write a word to the device without indexing to a register.
+
+        @param data Data to write.
+
+        @retval sfeTkError_t - kSTkErrOk on success
+    */
+    sfeTkError_t writeWord(uint16_t data);
+
+    /**
+        @brief Write an array of data to the device without indexing to a register.
+
+        @param data Data to write
+        @param length Length of Data
+
+        @retval sfeTkError_t - kSTkErrOk on success
+    */
+    sfeTkError_t writeRegion(const uint8_t *data, size_t length);
+
+    /**
         @brief Write a single byte to the given register
 
         @param devReg The device's register's address.


### PR DESCRIPTION
This adds two new functions that target the same functionality as `writeByte()`: `writeWord()` and `writeBlock()`. The intent is to be able to send data over I2C without indexing to a register. This is helpful in the case where the device simply expects I2C commands over I2C. Examples of this include products like the new Ultrasonic Distance Sensor, Quad Relay, Qwiic Twist, Qwiic RFID, etc. Basically devices, at least in the examples I listed, that have micro-controllers that act as peripherals. 

