### PR TITLE
16 bit data support -words vs bytes - 

### DIFF
--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -27,7 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
-#include "sfeTkError.h"
+#include "sfeToolkit.h"
 #include <stddef.h>
 
 /**

--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -230,6 +230,11 @@ class sfeTkIBus
      *
      */
     virtual sfeTkError_t readRegister16Region16(uint16_t reg, uint16_t *data, size_t numBytes, size_t &readBytes) = 0;
+
+    virtual uint8_t type(void)
+    {
+        return 0;
+    }
 };
 
 //};

--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -96,7 +96,7 @@ class sfeTkIBus
     virtual sfeTkError_t writeByte(uint8_t data) = 0;
 
     /**--------------------------------------------------------------------------
-     *  @brief Send a word to the device. 
+     *  @brief Send a word to the device.
      *  @param data Data to write.
      *
      *  @retval sfeTkError_t -  kSTkErrOk on successful execution.
@@ -161,6 +161,17 @@ class sfeTkIBus
     virtual sfeTkError_t writeRegister16Region(uint16_t devReg, const uint8_t *data, size_t length) = 0;
 
     /**--------------------------------------------------------------------------
+     *  @brief Writes a number of uint16's starting at the given register's 16-bit address.
+     *
+     *  @param devReg The device's register's address.
+     *  @param data Data to write.
+     *  @param length - length of data
+     *
+     *   @retval sfeTkError_t kSTkErrOk on successful execution
+     *
+     */
+    virtual sfeTkError_t writeRegister16Region16(uint16_t devReg, const uint16_t *data, size_t length) = 0;
+    /**--------------------------------------------------------------------------
      *  @brief Read a single byte from the given register
      *
      *  @param devReg The device's register's address.
@@ -206,6 +217,19 @@ class sfeTkIBus
      *
      */
     virtual sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes) = 0;
+
+    /**--------------------------------------------------------------------------
+     *  @brief Reads a block of data from the given 16-bit register address.
+     *
+     *   @param reg The device's 16 bit register's address.
+     *   @param data Data to write.
+     *   @param numBytes - length of data
+     *   @param[out] readBytes - number of bytes read
+     *
+     *   @retval int returns kSTkErrOk on success, or kSTkErrFail code
+     *
+     */
+    virtual sfeTkError_t readRegister16Region16(uint16_t reg, uint16_t *data, size_t numBytes, size_t &readBytes) = 0;
 };
 
 //};

--- a/src/sfeTk/sfeTkIBus.h
+++ b/src/sfeTk/sfeTkIBus.h
@@ -125,6 +125,12 @@ class sfeTkIBus
      */
     virtual sfeTkError_t writeRegisterByte(uint8_t devReg, uint8_t data) = 0;
 
+    // Overload version
+    sfeTkError_t writeRegister(uint8_t devReg, uint8_t data)
+    {
+        return writeRegisterByte(devReg, data);
+    }
+
     /**--------------------------------------------------------------------------
      * @brief Write a single word (16 bit) to the given register
      *
@@ -135,6 +141,12 @@ class sfeTkIBus
      *
      */
     virtual sfeTkError_t writeRegisterWord(uint8_t devReg, uint16_t data) = 0;
+
+    // Overload version
+    sfeTkError_t writeRegister(uint8_t devReg, uint16_t data)
+    {
+        return writeRegisterWord(devReg, data);
+    }
 
     /**--------------------------------------------------------------------------
      *  @brief Writes a number of bytes starting at the given register's address.
@@ -148,6 +160,12 @@ class sfeTkIBus
      */
     virtual sfeTkError_t writeRegisterRegion(uint8_t devReg, const uint8_t *data, size_t length) = 0;
 
+    // Overload version
+    sfeTkError_t writeRegister(uint8_t devReg, const uint8_t *data, size_t length)
+    {
+        return writeRegisterRegion(devReg, data, length);
+    }
+
     /**--------------------------------------------------------------------------
      *  @brief Writes a number of bytes starting at the given register's 16-bit address.
      *
@@ -160,6 +178,12 @@ class sfeTkIBus
      */
     virtual sfeTkError_t writeRegister16Region(uint16_t devReg, const uint8_t *data, size_t length) = 0;
 
+    // Overload version
+    sfeTkError_t writeRegister(uint16_t devReg, const uint8_t *data, size_t length)
+    {
+        return writeRegister16Region(devReg, data, length);
+    }
+
     /**--------------------------------------------------------------------------
      *  @brief Writes a number of uint16's starting at the given register's 16-bit address.
      *
@@ -171,6 +195,12 @@ class sfeTkIBus
      *
      */
     virtual sfeTkError_t writeRegister16Region16(uint16_t devReg, const uint16_t *data, size_t length) = 0;
+
+    // Overload version
+    sfeTkError_t writeRegister(uint16_t devReg, const uint16_t *data, size_t length)
+    {
+        return writeRegister16Region16(devReg, data, length);
+    }
     /**--------------------------------------------------------------------------
      *  @brief Read a single byte from the given register
      *
@@ -182,6 +212,12 @@ class sfeTkIBus
      */
     virtual sfeTkError_t readRegisterByte(uint8_t devReg, uint8_t &data) = 0;
 
+    // Overload version
+    sfeTkError_t readRegister(uint8_t devReg, uint8_t &data)
+    {
+        return readRegisterByte(devReg, data);
+    }
+
     /**--------------------------------------------------------------------------
      *  @brief Read a single word (16 bit) from the given register
      *
@@ -191,6 +227,12 @@ class sfeTkIBus
      *   @retval sfeTkError_t -  kSTkErrOk on successful execution.
      */
     virtual sfeTkError_t readRegisterWord(uint8_t devReg, uint16_t &data) = 0;
+
+    // Overload version
+    sfeTkError_t readRegister(uint8_t devReg, uint16_t &data)
+    {
+        return readRegisterWord(devReg, data);
+    }
 
     /**--------------------------------------------------------------------------
      *  @brief Reads a block of data from the given register.
@@ -205,6 +247,12 @@ class sfeTkIBus
      */
     virtual sfeTkError_t readRegisterRegion(uint8_t reg, uint8_t *data, size_t numBytes, size_t &readBytes) = 0;
 
+    // Overload version
+    sfeTkError_t readRegister(uint8_t reg, uint8_t *data, size_t numBytes, size_t &readBytes)
+    {
+        return readRegisterRegion(reg, data, numBytes, readBytes);
+    }
+
     /**--------------------------------------------------------------------------
      *  @brief Reads a block of data from the given 16-bit register address.
      *
@@ -218,6 +266,11 @@ class sfeTkIBus
      */
     virtual sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes) = 0;
 
+    // Overload version
+    sfeTkError_t readRegister(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes)
+    {
+        return readRegister16Region(reg, data, numBytes, readBytes);
+    }
     /**--------------------------------------------------------------------------
      *  @brief Reads a block of data from the given 16-bit register address.
      *
@@ -230,6 +283,12 @@ class sfeTkIBus
      *
      */
     virtual sfeTkError_t readRegister16Region16(uint16_t reg, uint16_t *data, size_t numBytes, size_t &readBytes) = 0;
+
+    // Overload version
+    sfeTkError_t readRegister(uint16_t reg, uint16_t *data, size_t numBytes, size_t &readBytes)
+    {
+        return readRegister16Region16(reg, data, numBytes, readBytes);
+    }
 
     virtual uint8_t type(void)
     {

--- a/src/sfeTk/sfeTkII2C.h
+++ b/src/sfeTk/sfeTkII2C.h
@@ -34,6 +34,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * The I2C bus interface extends the IBus interface and adds the ability to set and get the I2C
  * address and stop flag.
  */
+const uint8_t kBusTypeI2C = 0x01;
+
 class sfeTkII2C : public sfeTkIBus
 {
   public:
@@ -108,6 +110,11 @@ class sfeTkII2C : public sfeTkIBus
      * @brief kNoAddress is a constant to indicate no address has been set
      */
     static constexpr uint8_t kNoAddress = 0;
+
+    virtual uint8_t type(void)
+    {
+        return kBusTypeI2C;
+    }
 
   private:
     uint8_t _address;

--- a/src/sfeTk/sfeTkISPI.h
+++ b/src/sfeTk/sfeTkISPI.h
@@ -34,6 +34,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * The SPI bus interface extends the IBus interface and adds the ability to set and get the CS pin.
  */
+
+const uint8_t kBusTypeSPI = 0x02;
 class sfeTkISPI : public sfeTkIBus
 {
   public:
@@ -81,6 +83,11 @@ class sfeTkISPI : public sfeTkIBus
         @brief A constant for no CS pin
     */
     static constexpr uint8_t kNoCSPin = 0;
+
+    virtual uint8_t type(void)
+    {
+        return kBusTypeSPI;
+    }
 
   private:
     /** The internal storage of the _cs value*/

--- a/src/sfeTk/sfeToolkit.cpp
+++ b/src/sfeTk/sfeToolkit.cpp
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 #include "sfeToolkit.h"
 
+//---------------------------------------------------------------------------------
 /**
  * @brief C function - Runtime check for system byte order
  */
@@ -31,4 +32,40 @@ sfeTKByteOrder sfeToolkit::systemByteOrder(void)
 {
     uint16_t i = 1;
     return *((uint8_t *)&i) == 0 ? sfeTKByteOrder::BigEndian : sfeTKByteOrder::LittleEndian;
+}
+
+//---------------------------------------------------------------------------------
+/**
+ * @brief to catch 8 bit calls for byte swap
+ *
+ */
+uint8_t sfeToolkit::byte_swap(uint8_t i)
+{
+    return i;
+}
+//---------------------------------------------------------------------------------
+/**
+ * @brief function - Byte swap a 16 bit value
+ */
+uint16_t sfeToolkit::byte_swap(uint16_t i)
+{
+    // Use the fast intrinsic if available
+#if defined(__clang__) || defined(__GNUC__)
+    return __builtin_bswap16(i);
+#else
+    return (i << 8) | (i >> 8);
+#endif
+}
+
+//---------------------------------------------------------------------------------
+/**
+ * @brief function - Byte swap a 32 bit value
+ */
+uint32_t sfeToolkit::byte_swap(uint32_t i)
+{
+#if defined(__clang__) || defined(__GNUC__)
+    return __builtin_bswap32(i);
+#else
+    return ((i << 24) & 0xff000000) | ((i << 8) & 0x00ff0000) | ((i >> 8) & 0x0000ff00) | ((i >> 24) & 0x000000ff);
+#endif
 }

--- a/src/sfeTk/sfeToolkit.cpp
+++ b/src/sfeTk/sfeToolkit.cpp
@@ -23,13 +23,13 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 #include "sfeToolkit.h"
-#include <stdint.h>
+#include <cstdint>
 
 /**
  * @brief C function - Runtime check for system byte order
  */
-sfeTKByteOrder_t systemByteOrder(void)
+sfeTKByteOrder sfeToolkit::systemByteOrder(void)
 {
     uint16_t i = 1;
-    return *((uint8_t *)&i) == 0 ? SFETK_BIG_ENDIAN : SFETK_LITTLE_ENDIAN;
+    return *((uint8_t *)&i) == 0 ? sfeTKByteOrder::BigEndian : sfeTKByteOrder::LittleEndian;
 }

--- a/src/sfeTk/sfeToolkit.cpp
+++ b/src/sfeTk/sfeToolkit.cpp
@@ -23,7 +23,6 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 #include "sfeToolkit.h"
-#include <cstdint>
 
 /**
  * @brief C function - Runtime check for system byte order

--- a/src/sfeTk/sfeToolkit.cpp
+++ b/src/sfeTk/sfeToolkit.cpp
@@ -1,7 +1,6 @@
-
-// sfeToolkit.h
+// File: sfeToolkit.cpp
 //
-// General header file for the SparkFun Toolkit
+// General impl file for the SparkFun Toolkit
 /*
 
 The MIT License (MIT)
@@ -23,30 +22,14 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
 ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
-
-#pragma once
-
-/**
-    @brief Common include file for the core of the SparkFun Electronics Toolkit
-*/
-#include "sfeTkError.h"
+#include "sfeToolkit.h"
+#include <stdint.h>
 
 /**
-    @brief The byte order of the system
-*/
-typedef enum
+ * @brief C function - Runtime check for system byte order
+ */
+sfeTKByteOrder_t systemByteOrder(void)
 {
-    SFETK_BIG_ENDIAN = 0x01,
-    SFETK_LITTLE_ENDIAN = 0x00
-} sfeTKByteOrder_t;
-
-// Export our byte order function as a C function
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-    // Runtime check for system byte order
-    sfeTKByteOrder_t systemByteOrder(void);
-#ifdef __cplusplus
+    uint16_t i = 1;
+    return *((uint8_t *)&i) == 0 ? SFETK_BIG_ENDIAN : SFETK_LITTLE_ENDIAN;
 }
-#endif

--- a/src/sfeTk/sfeToolkit.h
+++ b/src/sfeTk/sfeToolkit.h
@@ -31,22 +31,18 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 #include "sfeTkError.h"
 
-/**
-    @brief The byte order of the system
-*/
-typedef enum
+// byte order types/enum
+enum class sfeTKByteOrder : uint8_t
 {
-    SFETK_BIG_ENDIAN = 0x01,
-    SFETK_LITTLE_ENDIAN = 0x00
-} sfeTKByteOrder_t;
+    BigEndian = 0x01,
+    LittleEndian = 0x02
+};
 
-// Export our byte order function as a C function
-#ifdef __cplusplus
-extern "C"
+// Use a namespace for the toolkit "utilities and helpers"
+namespace sfeToolkit
 {
-#endif
-    // Runtime check for system byte order
-    sfeTKByteOrder_t systemByteOrder(void);
-#ifdef __cplusplus
-}
-#endif
+
+// Function to determine the byte order of the system
+sfeTKByteOrder systemByteOrder(void);
+
+}; // namespace sfeToolkit

--- a/src/sfeTk/sfeToolkit.h
+++ b/src/sfeTk/sfeToolkit.h
@@ -26,6 +26,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
+#include <climits>
+#include <cstdint>
+#include <type_traits>
 /**
     @brief Common include file for the core of the SparkFun Electronics Toolkit
 */
@@ -41,8 +44,19 @@ enum class sfeTKByteOrder : uint8_t
 // Use a namespace for the toolkit "utilities and helpers"
 namespace sfeToolkit
 {
-
 // Function to determine the byte order of the system
 sfeTKByteOrder systemByteOrder(void);
+
+// Method to swap the byte order of any unsigned integer - you pick the size. Uses constexpr so it's a compile time
+// operation/inline/optimized
+//
+// from
+// https://stackoverflow.com/questions/36936584/how-to-write-constexpr-swap-function-to-change-endianess-of-an-integer
+//
+template <class T>
+constexpr typename std::enable_if<std::is_unsigned<T>::value, T>::type byte_swap(T i, T j = 0u, std::size_t n = 0u)
+{
+    return n == sizeof(T) ? j : byte_swap<T>(i >> CHAR_BIT, (j << CHAR_BIT) | (i & (T)(unsigned char)(-1)), n + 1);
+}
 
 }; // namespace sfeToolkit

--- a/src/sfeTk/sfeToolkit.h
+++ b/src/sfeTk/sfeToolkit.h
@@ -30,3 +30,19 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     @brief Common include file for the core of the SparkFun Electronics Toolkit
 */
 #include "sfeTkError.h"
+
+/**
+    @brief The byte order of the system
+*/
+typedef enum
+{
+    SFETK_BIG_ENDIAN = 0x01,
+    SFETK_LITTLE_ENDIAN = 0x00
+} sfeTKByteOrder_t;
+
+// Runtime check for system byte order
+constexpr sfeTKByteOrder_t systemByteOrder(void)
+{
+    uint16_t i = 1;
+    return *((uint8_t *)&i) == 0 ? SFETK_BIG_ENDIAN : SFETK_LITTLE_ENDIAN;
+}

--- a/src/sfeTk/sfeToolkit.h
+++ b/src/sfeTk/sfeToolkit.h
@@ -47,16 +47,8 @@ namespace sfeToolkit
 // Function to determine the byte order of the system
 sfeTKByteOrder systemByteOrder(void);
 
-// Method to swap the byte order of any unsigned integer - you pick the size. Uses constexpr so it's a compile time
-// operation/inline/optimized
-//
-// from
-// https://stackoverflow.com/questions/36936584/how-to-write-constexpr-swap-function-to-change-endianess-of-an-integer
-//
-template <class T>
-constexpr typename std::enable_if<std::is_unsigned<T>::value, T>::type byte_swap(T i, T j = 0u, std::size_t n = 0u)
-{
-    return n == sizeof(T) ? j : byte_swap<T>(i >> CHAR_BIT, (j << CHAR_BIT) | (i & (T)(unsigned char)(-1)), n + 1);
-}
+uint8_t byte_swap(uint8_t i);
+uint16_t byte_swap(uint16_t i);
+uint32_t byte_swap(uint32_t i);
 
 }; // namespace sfeToolkit

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -209,7 +209,8 @@ sfeTkError_t sfeTkArdI2C::writeRegisterRegion(uint8_t devReg, const uint8_t *dat
 //
 sfeTkError_t sfeTkArdI2C::writeRegister16Region(uint16_t devReg, const uint8_t *data, size_t length)
 {
-    devReg = ((devReg << 8) & 0xff00) | ((devReg >> 8) & 0x00ff);
+    // devReg = ((devReg << 8) & 0xff00) | ((devReg >> 8) & 0x00ff);
+    devReg = sfeToolkit::byte_swap(devReg);
     return writeRegisterRegionAddress((uint8_t *)&devReg, 2, data, length);
 }
 
@@ -227,7 +228,8 @@ sfeTkError_t sfeTkArdI2C::writeRegister16Region16(uint16_t devReg, const uint16_
         return writeRegisterRegionAddress((uint8_t *)&devReg, 2, (uint8_t *)data, length * 2);
 
     // okay, we need to swap
-    devReg = ((devReg << 8) & 0xff00) | ((devReg >> 8) & 0x00ff);
+    devReg = sfeToolkit::byte_swap(devReg);
+    // devReg = ((devReg << 8) & 0xff00) | ((devReg >> 8) & 0x00ff);
     uint16_t data16[length];
     for (size_t i = 0; i < length; i++)
         data16[i] = ((data[i] << 8) & 0xff00) | ((data[i] >> 8) & 0x00ff);

--- a/src/sfeTkArdI2C.cpp
+++ b/src/sfeTkArdI2C.cpp
@@ -223,7 +223,7 @@ sfeTkError_t sfeTkArdI2C::writeRegister16Region(uint16_t devReg, const uint8_t *
 sfeTkError_t sfeTkArdI2C::writeRegister16Region16(uint16_t devReg, const uint16_t *data, size_t length)
 {
     // if the system byte order is the same as the desired order, just send the buffer
-    if (systemByteOrder() == _byteOrder)
+    if (sfeToolkit::systemByteOrder() == _byteOrder)
         return writeRegisterRegionAddress((uint8_t *)&devReg, 2, (uint8_t *)data, length * 2);
 
     // okay, we need to swap
@@ -389,13 +389,13 @@ sfeTkError_t sfeTkArdI2C::readRegister16Region(uint16_t devReg, uint8_t *data, s
 sfeTkError_t sfeTkArdI2C::readRegister16Region16(uint16_t devReg, uint16_t *data, size_t numBytes, size_t &readBytes)
 {
     // if the system byte order is the same as the desired order, flip the address
-    if (systemByteOrder() != _byteOrder)
+    if (sfeToolkit::systemByteOrder() != _byteOrder)
         devReg = ((devReg << 8) & 0xff00) | ((devReg >> 8) & 0x00ff);
 
     sfeTkError_t status = readRegisterRegionAnyAddress((uint8_t *)&devReg, 2, (uint8_t *)data, numBytes * 2, readBytes);
 
     // Do we need to flip the byte order?
-    if (status == kSTkErrOk && systemByteOrder() != _byteOrder)
+    if (status == kSTkErrOk && sfeToolkit::systemByteOrder() != _byteOrder)
     {
         for (size_t i = 0; i < numBytes; i++)
             data[i] = ((data[i] << 8) & 0xff00) | ((data[i] >> 8) & 0x00ff);

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -41,9 +41,10 @@ class sfeTkArdI2C : public sfeTkII2C
 {
   public:
     /**
-        @brief Constructor
+    @brief Constructor
     */
-    sfeTkArdI2C(void) : _i2cPort(nullptr), _bufferChunkSize{kDefaultBufferChunk}
+
+    sfeTkArdI2C(void) : _i2cPort(nullptr), _bufferChunkSize{kDefaultBufferChunk}, _byteOrder{SFETK_LITTLE_ENDIAN}
     {
     }
     /**
@@ -291,6 +292,15 @@ class sfeTkArdI2C : public sfeTkII2C
         return _bufferChunkSize;
     }
 
+    /**
+     * @brief Set the byte order for multi-byte data transfers
+     *
+     */
+    void setByteOrder(sfeTKByteOrder_t order)
+    {
+        _byteOrder = order;
+    }
+
   protected:
     // note: The wire port is protected, allowing access if a sub-class is
     //      created to implement a special read/write routine
@@ -309,4 +319,7 @@ class sfeTkArdI2C : public sfeTkII2C
 
     /** The I2C buffer chunker - chunk size*/
     size_t _bufferChunkSize;
+
+    /** flag to manage byte swapping */
+    sfeTKByteOrder_t _byteOrder;
 };

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -259,13 +259,13 @@ class sfeTkArdI2C : public sfeTkII2C
 
         @param reg The device's 16 bit register's address.
         @param data Data buffer to read into
-        @param numBytes - Number of bytes to read/length of data buffer
-        @param[out] readBytes - number of bytes read
+        @param numWords - Number of words to read/length of data buffer
+        @param[out] readWords - number of words read
 
         @retval int returns kSTkErrOk on success, or kSTkErrFail code
 
     */
-    sfeTkError_t readRegister16Region16(uint16_t reg, uint16_t *data, size_t numBytes, size_t &readBytes);
+    sfeTkError_t readRegister16Region16(uint16_t reg, uint16_t *data, size_t numWords, size_t &readWords);
 
     // Buffer size chunk getter/setter
     /**

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -188,6 +188,18 @@ class sfeTkArdI2C : public sfeTkII2C
     sfeTkError_t writeRegister16Region(uint16_t devReg, const uint8_t *data, size_t length);
 
     /**
+        @brief Writes a number of bytes starting at the given register's 16-bit address.
+
+        @param devReg The device's register's address - 16 bit.
+        @param data Data to write.
+        @param length - length of data
+
+        @retval sfeTkError_t kSTkErrOk on successful execution
+
+    */
+    sfeTkError_t writeRegister16Region16(uint16_t devReg, const uint16_t *data, size_t length);
+
+    /**
         @brief Reads a byte of data from the given register.
 
         @note sfeTkIBus interface method
@@ -239,6 +251,19 @@ class sfeTkArdI2C : public sfeTkII2C
 
     */
     sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes);
+
+    /**
+        @brief Reads a block of data from the given 16-bit register address.
+
+        @param reg The device's 16 bit register's address.
+        @param data Data buffer to read into
+        @param numBytes - Number of bytes to read/length of data buffer
+        @param[out] readBytes - number of bytes read
+
+        @retval int returns kSTkErrOk on success, or kSTkErrFail code
+
+    */
+    sfeTkError_t readRegister16Region16(uint16_t reg, uint16_t *data, size_t numBytes, size_t &readBytes);
 
     // Buffer size chunk getter/setter
     /**

--- a/src/sfeTkArdI2C.h
+++ b/src/sfeTkArdI2C.h
@@ -31,6 +31,7 @@ over Inter-Integrated Circuit (I2C) in Arduino
 #include <Wire.h>
 
 // Include our platform I2C interface definition.
+#include "sfeTkArduino.h"
 #include <sfeTk/sfeTkII2C.h>
 
 /**
@@ -44,7 +45,7 @@ class sfeTkArdI2C : public sfeTkII2C
     @brief Constructor
     */
 
-    sfeTkArdI2C(void) : _i2cPort(nullptr), _bufferChunkSize{kDefaultBufferChunk}, _byteOrder{SFETK_LITTLE_ENDIAN}
+    sfeTkArdI2C(void) : _i2cPort(nullptr), _bufferChunkSize{kDefaultBufferChunk}, _byteOrder{SFTK_LSBFIRST}
     {
     }
     /**
@@ -295,8 +296,10 @@ class sfeTkArdI2C : public sfeTkII2C
     /**
      * @brief Set the byte order for multi-byte data transfers
      *
+     * @param order The byte order to set - set to either SFTK_MSBFIRST or SFTK_LSBFIRST. The default is SFTK_LSBFIRST
+     *
      */
-    void setByteOrder(sfeTKByteOrder_t order)
+    void setByteOrder(sfeTKByteOrder order)
     {
         _byteOrder = order;
     }
@@ -321,5 +324,5 @@ class sfeTkArdI2C : public sfeTkII2C
     size_t _bufferChunkSize;
 
     /** flag to manage byte swapping */
-    sfeTKByteOrder_t _byteOrder;
+    sfeTKByteOrder _byteOrder;
 };

--- a/src/sfeTkArdSPI.cpp
+++ b/src/sfeTkArdSPI.cpp
@@ -351,7 +351,7 @@ sfeTkError_t sfeTkArdSPI::readRegister16Region(uint16_t devReg, uint8_t *data, s
 //
 // Returns kSTkErrOk on success
 //
-sfeTkError_t sfeTkArdSPI::readRegister16Region16(uint16_t devReg, uint16_t *data, size_t numBytes, size_t &readBytes)
+sfeTkError_t sfeTkArdSPI::readRegister16Region16(uint16_t devReg, uint16_t *data, size_t numBytes, size_t &readWords)
 {
     if (!_spiPort)
         return kSTkErrBusNotInit;
@@ -372,7 +372,7 @@ sfeTkError_t sfeTkArdSPI::readRegister16Region16(uint16_t devReg, uint16_t *data
     digitalWrite(cs(), HIGH);
     _spiPort->endTransaction();
 
-    readBytes = numBytes;
+    readWords = numBytes;
 
     return kSTkErrOk;
 }

--- a/src/sfeTkArdSPI.cpp
+++ b/src/sfeTkArdSPI.cpp
@@ -363,7 +363,7 @@ sfeTkError_t sfeTkArdSPI::readRegister16Region16(uint16_t devReg, uint16_t *data
     digitalWrite(cs(), LOW);
 
     // A leading "1" must be added to transfer with devRegister to indicate a "read"
-    _spiPort->transfer16(devReg | kSPIReadBit);
+    _spiPort->transfer16(devReg);
 
     for (size_t i = 0; i < numBytes; i++)
         *data++ = _spiPort->transfer16(0x00);

--- a/src/sfeTkArdSPI.cpp
+++ b/src/sfeTkArdSPI.cpp
@@ -351,7 +351,7 @@ sfeTkError_t sfeTkArdSPI::readRegister16Region(uint16_t devReg, uint8_t *data, s
 //
 // Returns kSTkErrOk on success
 //
-sfeTkError_t sfeTkArdSPI::readRegister16Region16(uint16_t devReg, uint16_t *data, size_t numBytes, size_t &readWords)
+sfeTkError_t sfeTkArdSPI::readRegister16Region16(uint16_t devReg, uint16_t *data, size_t numWords, size_t &readWords)
 {
     if (!_spiPort)
         return kSTkErrBusNotInit;
@@ -365,14 +365,14 @@ sfeTkError_t sfeTkArdSPI::readRegister16Region16(uint16_t devReg, uint16_t *data
     // A leading "1" must be added to transfer with devRegister to indicate a "read"
     _spiPort->transfer16(devReg);
 
-    for (size_t i = 0; i < numBytes; i++)
+    for (size_t i = 0; i < numWords; i++)
         *data++ = _spiPort->transfer16(0x00);
 
     // End transaction
     digitalWrite(cs(), HIGH);
     _spiPort->endTransaction();
 
-    readWords = numBytes;
+    readWords = numWords;
 
     return kSTkErrOk;
 }

--- a/src/sfeTkArdSPI.h
+++ b/src/sfeTkArdSPI.h
@@ -27,6 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
+#include "sfeTkArduino.h"
 #include <SPI.h>
 #include <sfeTk/sfeTkISPI.h>
 

--- a/src/sfeTkArdSPI.h
+++ b/src/sfeTkArdSPI.h
@@ -243,12 +243,12 @@ class sfeTkArdSPI : public sfeTkISPI
 
             @param reg The device's register's 16 bit address.
             @param[out] data Data buffer to read into
-            @param numBytes - Length of data to read/size of data buffer
-            @param[out] readBytes - Number of bytes read
+            @param numWords - Length of data to read/size of data buffer
+            @param[out] readWords - Number of words read
 
             @retval sfeTkError_t - true on success
         */
-    virtual sfeTkError_t readRegister16Region16(uint16_t reg, uint16_t *data, size_t numBytes, size_t &readBytes);
+    virtual sfeTkError_t readRegister16Region16(uint16_t reg, uint16_t *data, size_t numWords, size_t &readWords);
 
   protected:
     // note: The instance data is protected, allowing access if a sub-class is

--- a/src/sfeTkArdSPI.h
+++ b/src/sfeTkArdSPI.h
@@ -179,6 +179,18 @@ class sfeTkArdSPI : public sfeTkISPI
     sfeTkError_t writeRegister16Region(uint16_t devReg, const uint8_t *data, size_t length);
 
     /**
+        @brief Writes a number of uint16s starting at the given register's address.
+        @note This method is virtual to allow it to be overridden to support a device that requires a unique impl
+
+        @param devReg The device's register's address.
+        @param data Data to write.
+        @param length - length of data
+
+        @retval sfeTkError_t - kSTkErrOk on success
+        */
+    sfeTkError_t writeRegister16Region16(uint16_t devReg, const uint16_t *data, size_t length);
+
+    /**
         @brief Read a single byte from the given register
 
         @param devReg The device's register's address.
@@ -223,6 +235,19 @@ class sfeTkArdSPI : public sfeTkISPI
         @retval sfeTkError_t - true on success
     */
     virtual sfeTkError_t readRegister16Region(uint16_t reg, uint8_t *data, size_t numBytes, size_t &readBytes);
+
+    /**
+            @brief Reads a block of data from the given register.
+            @note This method is virtual to allow it to be overridden to support a device that requires a unique impl
+
+            @param reg The device's register's 16 bit address.
+            @param[out] data Data buffer to read into
+            @param numBytes - Length of data to read/size of data buffer
+            @param[out] readBytes - Number of bytes read
+
+            @retval sfeTkError_t - true on success
+        */
+    virtual sfeTkError_t readRegister16Region16(uint16_t reg, uint16_t *data, size_t numBytes, size_t &readBytes);
 
   protected:
     // note: The instance data is protected, allowing access if a sub-class is

--- a/src/sfeTkArduino.h
+++ b/src/sfeTkArduino.h
@@ -1,6 +1,6 @@
 
 /*
-SparkFun_Toolkit.h
+@brief sfeTkArduino.h
 
 The MIT License (MIT)
 
@@ -27,10 +27,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // Purpose:
 //
-// The SparkFun Toolkit provides a set of common implementations used throughout our (and others)
-// Arduino Libraries.
+// "Arduino-ized" value of toolkit values constants"
 
 // Just include the toolkit headers
-#include "sfeTkArdI2C.h"
-#include "sfeTkArdSPI.h"
-#include "sfeTkArduino.h"
+
+#include <sfeTk/sfeToolkit.h>
+
+// Arduino-ize our byte order types
+
+const sfeTKByteOrder SFTK_MSBFIRST = sfeTKByteOrder::BigEndian;
+const sfeTKByteOrder SFTK_LSBFIRST = sfeTKByteOrder::LittleEndian;


### PR DESCRIPTION
-changing the naming of arguments to reflect words not bytes.
-@param[out] readWords on readRegister16Region16() is now being updated to the words written - to match how this is done in the SPI equivalent function.