### PR TITLE
quick fix for the toolkit UART compile/builds issues on some platforms

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Toolkit
-version=1.1.0
+version=1.1.1
 author=SparkFun Electronics
 maintainer=SparkFun Electronics
 sentence=A utility library that other SparkFun libraries can take advantage of.

--- a/src/sfTk/sfTkIUART.h
+++ b/src/sfTk/sfTkIUART.h
@@ -68,7 +68,7 @@ typedef enum _sfTkUARTDataBits
     kUARTDataBitsEight = 0x400ul,
 } sfTkUARTDataBits_t;
 
-inline const uint8_t dataBitsToValue(sfTkUARTDataBits_t dataBits)
+inline uint8_t dataBitsToValue(sfTkUARTDataBits_t dataBits)
 {
     static const uint8_t dataBitsArray[] = {5, 6, 7, 8};
 

--- a/src/sfTkArdUART.cpp
+++ b/src/sfTkArdUART.cpp
@@ -48,7 +48,8 @@ sfTkError_t sfTkArdUART::init(HardwareSerial &hwSerial, uint32_t baudRate, bool 
 
 sfTkError_t sfTkArdUART::init(uint32_t baudRate, bool bInit)
 {
-#ifdef _THIS__NOT_IS_BROKEN
+    // issues here on some devices - $defineing out for now
+#ifdef _THIS_IS_BROKEN
     // if we don't have a port already, use the default Arduino Serial.
     if (!_hwSerial)
         return init(Serial, baudRate, bInit);
@@ -62,7 +63,8 @@ sfTkError_t sfTkArdUART::init(uint32_t baudRate, bool bInit)
 
 sfTkError_t sfTkArdUART::init(sfTkIUART::UARTConfig_t config, bool bInit)
 {
-#ifdef _THIS__NOT_IS_BROKEN
+// issues here on some devices - $defineing out for now
+#ifdef _THIS_IS_BROKEN
     // if we don't have a port already, use the default Arduino Serial.
     if (!_hwSerial)
         return init(Serial, config, bInit);

--- a/src/sfTkArdUART.cpp
+++ b/src/sfTkArdUART.cpp
@@ -48,16 +48,21 @@ sfTkError_t sfTkArdUART::init(HardwareSerial &hwSerial, uint32_t baudRate, bool 
 
 sfTkError_t sfTkArdUART::init(uint32_t baudRate, bool bInit)
 {
+#ifdef _THIS__NOT_IS_BROKEN
     // if we don't have a port already, use the default Arduino Serial.
     if (!_hwSerial)
         return init(Serial, baudRate, bInit);
 
     // We already have a UART setup, so it's already initialized. Change the baud rate.
     return setBaudRate(baudRate); // set the baud rate
+#else
+    return ksfTkErrFail;
+#endif
 }
 
 sfTkError_t sfTkArdUART::init(sfTkIUART::UARTConfig_t config, bool bInit)
 {
+#ifdef _THIS__NOT_IS_BROKEN
     // if we don't have a port already, use the default Arduino Serial.
     if (!_hwSerial)
         return init(Serial, config, bInit);
@@ -67,6 +72,9 @@ sfTkError_t sfTkArdUART::init(sfTkIUART::UARTConfig_t config, bool bInit)
 
     // We already have a UART setup, so it's already initialized.
     return ksfTkErrOk;
+#else
+    return ksfTkErrFail;
+#endif
 }
 
 sfTkError_t sfTkArdUART::init()
@@ -103,11 +111,11 @@ sfTkError_t sfTkArdUART::read(uint8_t *data, size_t length, size_t &bytesRead)
 
     bytesRead = 0; // zero out value
 
-// #ifdef ARDUINO_ARCH_AVR
+    // #ifdef ARDUINO_ARCH_AVR
     bytesRead = _hwSerial->readBytes(data, length);
-// #else
-//     bytesRead = readBytes(data, length);
-// #endif
+    // #else
+    //     bytesRead = readBytes(data, length);
+    // #endif
 
     if (bytesRead == 0)
         return ksfTkErrFail;
@@ -187,7 +195,8 @@ sfTkError_t sfTkArdUART::_start(void)
     // ESP8266 does not support setting stop bits, parity, and data bits in a stanard manner.
     _hwSerial->begin(_config.baudRate);
 #else
-    _hwSerial->begin(_config.baudRate, _config.stopBits | _config.parity | _config.dataBits);
+    _hwSerial->begin(_config.baudRate,
+                     (uint32_t)_config.stopBits | (uint32_t)_config.parity | (uint32_t)_config.dataBits);
 #endif
     if (!availableForWrite())
         return ksfTkErrSerialNotInit; // check if the port is available


### PR DESCRIPTION
I #defined out the failing code (Serial is not always Hardware Serial) and fixed a enum casting issue.

Please verify this compiles everywhere (I checked key areas).

We and do a perm fix later. 